### PR TITLE
Count hardlinks once

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-duc-index
+++ b/root/etc/e-smith/events/actions/nethserver-duc-index
@@ -24,7 +24,7 @@ DUC_DB=$JSON_DIR/duc.db
 SIZE=10000000
 
 # directory indexing
-/usr/bin/duc index $INDEX_DIR -d $DUC_DB
+/usr/bin/duc index --check-hard-links $INDEX_DIR -d $DUC_DB
 
 # parse db into xml
 /usr/bin/duc xml -s $SIZE -x -d $DUC_DB $INDEX_DIR > $JSON_DIR/tree.xml


### PR DESCRIPTION
NethServer/dev#5582
#

Hardlinked files are counted twice. 
As an result the overall total of disk usage can deviate quite much  from the report on the dashboard or 
by "du" for the given directory with containing hardlinks. 

From duc manual: 
>-H, --check-hard-links
count hard links only once. if two or more hard links point to the same file, only one of the hard links is displayed and counted.

This comes with the trade-off indexing will be a bit slower.

#
also see: https://community.nethserver.org/t/duc-reports-wrong/10742




